### PR TITLE
Fix readability + minor semantic issues in Python files

### DIFF
--- a/planning_simulator_launcher/scenario_generator.py
+++ b/planning_simulator_launcher/scenario_generator.py
@@ -1,14 +1,10 @@
-#!/usr/bin/env python
-
-from copy import deepcopy
-import datetime
 import itertools
 import json
-import math
 import os
 import re
-import shutil
 import uuid
+from copy import deepcopy
+
 import yaml
 
 
@@ -36,30 +32,30 @@ class ScenarioGenerator:
         with open(path, "r+") as file:
             self.yaml_str = file.read()
 
-        self.__yaml_generate_dir = self.generated_directory + "/" + scenario_name + "/"
+        self._yaml_generate_dir = self.generated_directory + "/" + scenario_name + "/"
 
-        if os.path.exists(self.__yaml_generate_dir):
+        if os.path.exists(self._yaml_generate_dir):
             print('')
-            print('Cleanup target directory ' + os.path.relpath(self.__yaml_generate_dir))
+            print('Cleanup target directory ' + os.path.relpath(self._yaml_generate_dir))
 
-            for each in os.listdir(self.__yaml_generate_dir):
+            for each in os.listdir(self._yaml_generate_dir):
                 print('    Removing ' + each)
-                os.remove(os.path.join(self.__yaml_generate_dir, each))
+                os.remove(os.path.join(self._yaml_generate_dir, each))
         else:
-            os.makedirs(self.__yaml_generate_dir)
+            os.makedirs(self._yaml_generate_dir)
 
         print('')
         print("Generating scenario " + scenario_name)
-        self.__generate()
+        self._generate()
 
     def __del__(self):
         self.generate_log.close()
 
     def getScenarioFilesPath(self):
-        return self.__yaml_files_path
+        return self._yaml_files_path
 
-    def __generate(self):
-        self.__yaml_files_path = []
+    def _generate(self):
+        self._yaml_files_path = []
         self.num_scenarios = 0
 
         print('    Parameters')
@@ -86,8 +82,8 @@ class ScenarioGenerator:
             for bindings in itertools.product(*list_of_list_of_bindings):
                 scenario_id = str(uuid.uuid4())
 
-                yaml_path = self.__yaml_generate_dir + scenario_id + ".yaml"
-                self.__yaml_files_path.append(yaml_path)
+                yaml_path = self._yaml_generate_dir + scenario_id + ".yaml"
+                self._yaml_files_path.append(yaml_path)
                 print('')
                 print('    ' + os.path.relpath(yaml_path))
 
@@ -122,8 +118,8 @@ class ScenarioGenerator:
         else:
             scenario_id = str(uuid.uuid4())
 
-            yaml_path = self.__yaml_generate_dir + scenario_id + ".yaml"
-            self.__yaml_files_path.append(yaml_path)
+            yaml_path = self._yaml_generate_dir + scenario_id + ".yaml"
+            self._yaml_files_path.append(yaml_path)
             print('    ' + os.path.relpath(yaml_path))
 
             result = deepcopy(self.yaml_str)
@@ -143,7 +139,7 @@ class ScenarioGenerator:
 
         json.dump(generate_logs, self.generate_log)
 
-    def __getDefaultValueKeys(self, used_key):
+    def _getDefaultValueKeys(self, used_key):
         variables = []
 
         for variable in self.params.keys():
@@ -156,8 +152,8 @@ class ScenarioGenerator:
 
         return variables
 
-    def __update_default_params(self, name, yaml_string):
-        for variable in self.__getDefaultValueKeys(name):
+    def _update_default_params(self, name, yaml_string):
+        for variable in self._getDefaultValueKeys(name):
             print('       '),
             print(variable),
             print('=>'),
@@ -169,8 +165,8 @@ class ScenarioGenerator:
         return yaml_string
 
     def evaluate(self, match):
-        pi = math.pi
         return match.group(1) + str(eval(match.group(2))) + match.group(3)
 
     def macroexpand(self, source):
-        return re.sub(r"^(.*)\${{\s+((?:pi|[\d\s+\-\*/%\(\).])*)\s+}}(.*)$", self.evaluate, source, flags=re.M)
+        regex = r"^(.*)\${{\s+((?:pi|[\d\s+\-\*/%\(\).])*)\s+}}(.*)$"
+        return re.sub(regex, self.evaluate, source, flags=re.M)

--- a/planning_simulator_launcher/scenario_parameter.py
+++ b/planning_simulator_launcher/scenario_parameter.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import numpy as np
 
 
@@ -17,29 +15,29 @@ class ScenarioParameter:
             return
 
         if 'Min' in yaml:
-            self.__min = yaml['Min']
+            self._min = yaml['Min']
         elif 'Value' in yaml:
-            self.__min = yaml['Value']
+            self._min = yaml['Value']
         else:
-            self.__min = 0
+            self._min = 0
 
-        print('        Min: ' + str(self.__min))
+        print('        Min: ' + str(self._min))
 
         if 'Max' in yaml:
-            self.__max = yaml['Max']
+            self._max = yaml['Max']
         else:
-            self.__max = self.__min
+            self._max = self._min
 
-        print('        Max: ' + str(self.__max))
+        print('        Max: ' + str(self._max))
 
         if 'NumDivisions' in yaml:
-            self.__num_divisions = yaml['NumDivisions']
+            self._num_divisions = yaml['NumDivisions']
         else:
-            self.__num_divisions = 1
+            self._num_divisions = 1
 
-        print('        NumDivisions: ' + str(self.__num_divisions))
+        print('        NumDivisions: ' + str(self._num_divisions))
 
-        self.values = np.linspace(self.__min, self.__max, self.__num_divisions)
+        self.values = np.linspace(self._min, self._max, self._num_divisions)
         # print('        Values:'),
         # print(self.values)
 

--- a/planning_simulator_launcher/scenario_parser.py
+++ b/planning_simulator_launcher/scenario_parser.py
@@ -1,9 +1,7 @@
-#!/usr/bin/env python
+import yaml
 
 from planning_simulator_launcher.scenario_generator import ScenarioGenerator
 from planning_simulator_launcher.scenario_parameter import ScenarioParameter
-import os
-import yaml
 
 
 class ScenarioParser:
@@ -50,7 +48,3 @@ class ScenarioParser:
             return False
 
         return True
-
-
-if __name__ == "__main__":
-    pass

--- a/planning_simulator_launcher/scenario_parser.py
+++ b/planning_simulator_launcher/scenario_parser.py
@@ -1,3 +1,4 @@
+import os
 import yaml
 
 from planning_simulator_launcher.scenario_generator import ScenarioGenerator

--- a/planning_simulator_launcher/show_result.py
+++ b/planning_simulator_launcher/show_result.py
@@ -1,12 +1,12 @@
-#!/usr/bin/env python
-
 import argparse
 import glob
 import json
+
 import termcolor
 
+
 class Viewer:
-    def __init__(self,scenario_generated_path,log_path,verbose,quiet,output):
+    def __init__(self, scenario_generated_path, log_path, verbose, quiet, output):
         self.quiet = quiet
         self.verbose = verbose
         self.log_path = log_path
@@ -23,21 +23,23 @@ class Viewer:
             self.raw_data[scenario_id] = json_load
             if self.getGenerateLog(scenario_id) is not None:
                 self.output_data.append(self.getResultDict(scenario_id))
-        if self.quiet == False:
+        if not self.quiet:
             self.outputResult(output)
             self.printResult()
+
     def printResult(self):
         if self.verbose:
             self.printVerboseResult()
         else:
             self.printSimpleResult()
         self.printSummary()
+
     def printVerboseResult(self):
         i = 1
         for data in self.output_data:
             message = "[" + str(i) + "/" + str(len(self.output_data)) + "] "
             if data["passed"]:
-                message = message +  "OK \n"
+                message = message + "OK \n"
             else:
                 message = message + "NG \n"
             message = message + "id = " + data["id"] + "\n"
@@ -53,7 +55,8 @@ class Viewer:
                 message = message + "    no scenario parameters"
             param_index = 1
             for param in data["params"]:
-                message = message + "    (" + str(param_index) + "/" + str(len(data["params"])) + ") " + param + " : " + str(data["params"][param])
+                message = message + "    (" + str(param_index) + "/" + str(len(data["params"])) \
+                    + ") " + param + " : " + str(data["params"][param])
                 param_index = param_index + 1
             message = message + "\n"
             if data["passed"]:
@@ -62,12 +65,13 @@ class Viewer:
                 message = termcolor.colored(message, 'red')
             print(message)
             i = i + 1
+
     def printSimpleResult(self):
         i = 1
         for data in self.output_data:
             message = "[" + str(i) + "/" + str(len(self.output_data)) + "] "
             if data["passed"]:
-                message = message +  "OK "
+                message = message + "OK "
             else:
                 message = message + "NG "
             message = message + "id = " + data["id"]
@@ -77,6 +81,7 @@ class Viewer:
                 message = termcolor.colored(message, 'red')
             print(message)
             i = i + 1
+
     def printSummary(self):
         print("[summary]")
         i = 0
@@ -84,16 +89,19 @@ class Viewer:
             if data["passed"]:
                 i = i + 1
         print("passed " + str(i) + "/" + str(len(self.output_data)) + " test cases.")
-    def outputResult(self,output):
-        if output != None:
+
+    def outputResult(self, output):
+        if output is not None:
             with open(output, 'w') as f:
                 json.dump(self.output_data, f, indent=4)
-    def getGenerateLog(self,id):
+
+    def getGenerateLog(self, id):
         for log in self.generate_log:
             if log["id"] == id:
                 return log
         return None
-    def getResultDict(self,id):
+
+    def getResultDict(self, id):
         ret = {}
         if self.getResult(id):
             ret["passed"] = True
@@ -102,7 +110,7 @@ class Viewer:
         gen_log = self.getGenerateLog(id)
         ret["parent"] = gen_log["parent_path"]
         ret["id"] = id
-        ret["json_log"] = self.log_path +  id + ".json"
+        ret["json_log"] = self.log_path + id + ".json"
         ret["rosbag"] = self.log_path + id + ".bag"
         metadata = self.raw_data[id]["metadata"]
         ret["metadata"] = metadata
@@ -113,7 +121,8 @@ class Viewer:
         else:
             ret["params"] = {}
         return ret
-    def getResult(self,id):
+
+    def getResult(self, id):
         logs = self.raw_data[id]["log"]
         scenario_succeded = False
         for log in logs:
@@ -128,13 +137,34 @@ class Viewer:
 
 def main():
     parser = argparse.ArgumentParser(description='Show result')
-    parser.add_argument('scenario_generated_path', type=str, help='path of the generated scenario')
-    parser.add_argument('log_path', type=str,help='path of the log')
-    parser.add_argument('--verbose', help='show detail or not', action="store_true")
-    parser.add_argument('--quiet', help='does not show output', action="store_true")
-    parser.add_argument('--output',type=str,help='output path of the result(if not set, only output result to the screen)')
+    parser.add_argument(
+        'scenario_generated_path',
+        type=str,
+        help='path of the generated scenario'
+    )
+    parser.add_argument(
+        'log_path',
+        type=str,
+        help='path of the log'
+    )
+    parser.add_argument(
+        '--verbose',
+        help='show detail or not',
+        action="store_true"
+    )
+    parser.add_argument(
+        '--quiet',
+        help='does not show output',
+        action="store_true"
+    )
+    parser.add_argument(
+        '--output',
+        type=str,
+        help='output path of the result(if not set, only output result to the screen)'
+    )
     args = parser.parse_args()
-    viwer = Viewer(args.scenario_generated_path,args.log_path,args.verbose,args.quiet,args.output)
+    Viewer(args.scenario_generated_path, args.log_path, args.verbose, args.quiet, args.output)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
This is only a separate PR to make the diff smaller. I know style changes are not needed yet, but this took five minutes and I was waiting anyway for things to compile.

* Removed `#!/usr/bin/env python`, it is not needed for libraries at all and even for the executable, `ros2 run` takes care of selecting the interpreter
* Fixed lint issues pointed out by `flake8` and ran `isort`
* Changed double underscores to single underscores since [double underscores have special meaning in Python](https://dbader.org/blog/meaning-of-underscores-in-python).