### PR TITLE
Ros2 add missing options

### DIFF
--- a/planning_simulator_launcher/launch.py
+++ b/planning_simulator_launcher/launch.py
@@ -126,6 +126,7 @@ class Launcher:
                     'sensor_model': self.sensor_model,
                     'vehicle_model': self.vehicle_model,
                     'initial_engage_state': "False",
+                    'perception/enable_detection_failure': "False",
                 }
                 ld = launch_description(
                     launch_path=str(self.launch_path),

--- a/planning_simulator_launcher/launch.py
+++ b/planning_simulator_launcher/launch.py
@@ -127,6 +127,7 @@ class Launcher:
                     'vehicle_model': self.vehicle_model,
                     'initial_engage_state': "False",
                     'perception/enable_detection_failure': "False",
+                    'sensing/visible_range': "1000.0",
                 }
                 ld = launch_description(
                     launch_path=str(self.launch_path),


### PR DESCRIPTION
add missing options to launch.py
(ref. https://github.com/tier4/scenario_runner.iv.universe/blob/master/api/scenario_api/launch/scenario.launch#L40-L41 )


## How to check
- launch scenario ($ros2 run planning_simulator_launcher launch_main ...)
- $ros2 param get /simulation/dummy_perception_publisher detection_successful_rate # return 1.0
- $ros2 param get /simulation/dummy_perception_publisher visible_range #return 1000.0

